### PR TITLE
Validate postMessage source in iframe_listener (CWE-346)

### DIFF
--- a/backend/services/browser/scripts/iframe_listener.js
+++ b/backend/services/browser/scripts/iframe_listener.js
@@ -4,10 +4,33 @@
 		return;
 	}
 	window.__browserwingIframeListener__ = true;
+
+	// 验证消息来源是否为当前页面的子 iframe
+	var isChildIframe = function(source) {
+		try {
+			var iframes = document.querySelectorAll('iframe');
+			for (var i = 0; i < iframes.length; i++) {
+				if (iframes[i].contentWindow === source) {
+					return true;
+				}
+			}
+		} catch (e) {
+			// 跨域 iframe 访问 contentWindow 可能抛出异常,
+			// 但 event.source 引用比较本身不会抛出异常
+			console.warn('[BrowserWing] iframe source check error:', e);
+		}
+		return false;
+	};
 	
 	window.addEventListener('message', function(event) {
 		try {
 			if (event.data && event.data.type === '__browserwing_iframe_action__') {
+				// 验证消息来源: 只接受来自当前页面子 iframe 的消息
+				if (!event.source || !isChildIframe(event.source)) {
+					console.warn('[BrowserWing] ⊘ Rejected iframe action from untrusted source');
+					return;
+				}
+
 				var action = event.data.action;
 				if (action && window.__recordedActions__) {
 					// 去重逻辑：检查最近的操作是否与当前操作重复


### PR DESCRIPTION
## Summary

`backend/services/browser/scripts/iframe_listener.js` is injected into every page the user is recording with BrowserWing. Its `message` handler accepts any `postMessage` whose `event.data.type === '__browserwing_iframe_action__'` and appends the contained `action` to `window.__recordedActions__`, which is later persisted to `sessionStorage` and synced to the backend as part of the recording.

The handler does not validate `event.source` or `event.origin`. As a result, any script running in the recorded page (the page itself, third-party scripts, or any cross-origin frame embedded in it) can call:

```javascript
window.parent.postMessage({
  type: '__browserwing_iframe_action__',
  action: { /* attacker-chosen recorded action */ }
}, '*');
```

…and inject arbitrary fabricated actions into the user's recording.

- **CWE:** [CWE-346: Origin Validation Error](https://cwe.mitre.org/data/definitions/346.html)
- **File / function:** `backend/services/browser/scripts/iframe_listener.js`, the `message` event listener registered on `window`
- **Data flow:** `window.postMessage` (attacker-controlled page or embedded frame) → `message` event handler → `event.data.action` → `window.__recordedActions__` → `sessionStorage` → backend recording

## Fix

Validate that `event.source` is the `contentWindow` of an `<iframe>` element in the current document before accepting the message. The legitimate sender for `__browserwing_iframe_action__` is a child iframe forwarding its own captured action to the top frame; messages from any other source (including the top window itself, sibling tabs/openers, or unrelated cross-origin frames calling `window.parent.postMessage`) are rejected.

Reference comparison (`iframes[i].contentWindow === source`) does not require same-origin access and works for cross-origin child iframes — which is the legitimate case this listener is designed for.

## Why this is exploitable

Preconditions:
1. The user is actively recording a session with BrowserWing.
2. The recorded page contains attacker-controlled JS — either because it's an attacker-owned origin, includes a malicious third-party script, or embeds an attacker-controlled frame that can `postMessage` to its parent.

Under those preconditions, the attacker can silently inject any number of fabricated `action` entries into the recording. Because the recording is later persisted and replayable, this lets an attacker poison a recording with actions the user never performed (fake clicks, inputs, navigations), which can mislead anyone reviewing or replaying the recording and could be leveraged to drive subsequent automated replay against other targets.

Impact is limited to recording integrity — not RCE — but it silently breaks a core trust property of the recorder: that recorded actions reflect what the user actually did.

## Testing

- Reviewed all `postMessage` / `message` listener code paths in `backend/services/browser/scripts/`. The legitimate producer of `__browserwing_iframe_action__` is the iframe-side script, which sends from a child iframe's window — this case continues to satisfy the new check.
- Verified that a top-frame self-`postMessage` (`window.postMessage(...)`) has `event.source === window`, which is not in `document.querySelectorAll('iframe')`, so it is correctly rejected.
- Verified that cross-origin child iframes still work: `HTMLIFrameElement.contentWindow` is readable across origins, and `===` reference equality with `event.source` does not throw.
- Confirmed no other handler in the codebase consumes this message type, so tightening the source check does not regress any other path.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether any existing origin/source validation was in place (none — neither `event.origin` nor `event.source` is consulted anywhere in the handler), whether the preconditions trivially imply equivalent capability (they don't — attacker JS in the page cannot otherwise write to `__recordedActions__` in a way that survives into the persisted recording without going through this listener, since the recording pipeline only consumes its own captured events plus these iframe messages), and whether browser-level protections would block the spoofed `postMessage` (they don't — `postMessage` to `window.parent` with `'*'` is a standard, unblocked operation). The exploit path is real, though impact is bounded to recording-integrity poisoning rather than code execution.

cc @lewiswigmore
