### PR TITLE
security: verify SHA-256 checksum of downloaded binaries in npm postinstall

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -9,12 +9,32 @@ const https = require('https');
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { execSync } = require('child_process');
 const os = require('os');
 
 const REPO = 'browserwing/browserwing';
 const VERSION = require('./package.json').version;
 const TAG = `v${VERSION}`;
+
+/**
+ * SHA-256 checksums for release archives.
+ *
+ * These MUST be updated every time a new release is published.
+ * Generate with:
+ *   shasum -a 256 browserwing-*.tar.gz browserwing-*.zip
+ *
+ * To skip verification (e.g. during local development), set the
+ * environment variable BROWSERWING_SKIP_CHECKSUM=1.
+ */
+const CHECKSUMS = {
+  'browserwing-darwin-amd64.tar.gz':  '',
+  'browserwing-darwin-arm64.tar.gz':  '',
+  'browserwing-linux-amd64.tar.gz':   '',
+  'browserwing-linux-arm64.tar.gz':   '',
+  'browserwing-windows-amd64.zip':    '',
+  'browserwing-windows-arm64.zip':    '',
+};
 
 // ANSI color codes
 const colors = {
@@ -220,6 +240,50 @@ function downloadFileOnce(url, dest) {
   });
 }
 
+/**
+ * Verify the SHA-256 checksum of a downloaded file.
+ *
+ * Throws if the computed hash does not match the expected value stored in
+ * CHECKSUMS.  When BROWSERWING_SKIP_CHECKSUM=1 is set or the expected hash
+ * is empty (not yet populated for this release) verification is skipped with
+ * a warning so that development builds still work.
+ */
+function verifyChecksum(filePath, archiveName) {
+  if (process.env.BROWSERWING_SKIP_CHECKSUM === '1') {
+    logWarning('Checksum verification skipped (BROWSERWING_SKIP_CHECKSUM=1)');
+    return;
+  }
+
+  const expectedHash = CHECKSUMS[archiveName];
+
+  if (!expectedHash) {
+    logWarning(
+      `No checksum available for ${archiveName}. ` +
+      'Integrity verification skipped — please update CHECKSUMS in install.js.'
+    );
+    return;
+  }
+
+  logInfo('Verifying archive integrity (SHA-256)...');
+
+  const fileBuffer = fs.readFileSync(filePath);
+  const actualHash = crypto.createHash('sha256').update(fileBuffer).digest('hex');
+
+  if (actualHash !== expectedHash) {
+    // Remove the untrusted file immediately
+    try { fs.unlinkSync(filePath); } catch (_) { /* best effort */ }
+    throw new Error(
+      `Checksum mismatch for ${archiveName}!\n` +
+      `  Expected: ${expectedHash}\n` +
+      `  Actual:   ${actualHash}\n` +
+      'The downloaded file may have been tampered with. ' +
+      'Installation aborted for security.'
+    );
+  }
+
+  logInfo(`Checksum verified: ${actualHash}`);
+}
+
 // Extract archive
 function extractArchive(archivePath, destDir, isWindows) {
   logInfo('Extracting archive...');
@@ -301,6 +365,9 @@ async function install() {
 
     // Download archive
     await downloadFile(archiveName, archivePath);
+
+    // Verify integrity before extraction
+    verifyChecksum(archivePath, archiveName);
 
     // Extract archive
     extractArchive(archivePath, binDir, isWindows);


### PR DESCRIPTION
## Summary

The npm postinstall script (`npm/install.js`) downloads platform-specific binary archives from GitHub Releases and a Gitee mirror, then extracts and marks them executable — without verifying their integrity. A compromise of either upstream (or an on-path attacker with a valid TLS cert) results in arbitrary code execution on every machine that runs `npm install browserwing`.

This PR adds a SHA-256 verification step that runs after download and before extraction.

## Vulnerability details

- **File:** `npm/install.js`
- **Function:** `install()` → `downloadFile()` → `extractArchive()`
- **Class:** CWE-494 (Download of Code Without Integrity Check) / CWE-829 (Inclusion of Functionality from Untrusted Control Sphere). Leads to CWE-94 style code execution.
- **Trigger:** `install()` runs unconditionally at the bottom of the file, so it executes on every `npm install browserwing`.

### Data flow

1. `selectMirror()` races GitHub releases and a Gitee mirror, picking whichever HEAD responds first. For users in regions where Gitee is faster, the Gitee mirror is effectively always selected.
2. `downloadFile()` writes the archive to a temp directory.
3. `extractArchive()` unpacks it; the resulting binary is `chmod 0755` and becomes the `browserwing` CLI on the user's `PATH`.
4. No hash, signature, or size check exists between (2) and (3).

### Why it's exploitable

The two upstreams sit in **different trust domains**:

- **Gitee mirror** — separate account, separate platform, separate credentials from npm/GitHub. A single account compromise on Gitee silently backdoors every install that picks that mirror.
- **GitHub Releases** — compromise of a maintainer token or a release-publishing workflow has the same effect.
- **TLS MITM with a valid cert** — harder, but historically not unprecedented for targeted attacks.

In all three cases, the npm install itself is the code-execution primitive — none of the preconditions already grant code execution on end-user machines, so this is a real boundary crossing rather than a redundant capability.

## Fix

Adds `verifyChecksum(filePath, archiveName)` invoked between download and extraction:

- Computes SHA-256 over the downloaded archive and compares against an expected hash stored in a `CHECKSUMS` map keyed by archive filename.
- On mismatch: deletes the untrusted file (`fs.unlinkSync`) and throws, aborting installation before extraction or `chmod` happens.
- Provides a `BROWSERWING_SKIP_CHECKSUM=1` escape hatch for local development against unreleased builds.
- If the expected hash for an archive is empty, logs a warning and continues — this preserves current behaviour for releases that have not yet had their hashes populated, so this PR does not break any existing release.

The crypto usage is the standard Node pattern (`crypto.createHash('sha256').update(buf).digest('hex')`).

### Operational follow-up required

The `CHECKSUMS` map ships with empty strings. **For the protection to actually take effect, the release process needs to populate these per release.** Two options:

1. Update the `CHECKSUMS` constant in `install.js` as part of each release commit (simple, what the doc-comment suggests).
2. Better long-term: have the release workflow publish a `SHA256SUMS` file alongside the archives, and have `install.js` fetch and parse that. Happy to follow up with a second PR for option 2 if preferred.

I kept this PR minimal (single function + call site + constant) to make the security fix easy to review and merge independently of the release-automation change.

## Testing

- Ran `node -c npm/install.js` — syntax OK.
- Manually exercised `verifyChecksum()` with:
  - matching hash → passes and logs the verified hash;
  - mismatching hash → throws with a clear error and unlinks the file (verified the file is removed);
  - empty expected hash → warns and continues (preserves current behaviour);
  - `BROWSERWING_SKIP_CHECKSUM=1` → warns and skips.
- Diff is +67 / -0, scoped to `npm/install.js`.

## Adversarial review

Before submitting, we tried to disprove this. The two things that could make it a non-issue would be (a) an existing integrity check somewhere in the install path, or (b) the preconditions for exploitation already implying code execution on the victim. Neither holds: there is no hash/signature check anywhere between download and `chmod 0755`, and a Gitee-account or release-artifact compromise does not by itself give the attacker code execution on end-user machines — the unverified postinstall is what bridges that gap. HTTPS only defends against passive MITM, not against a compromised upstream.

cc @lewiswigmore
