### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/backend/agent/agent_llm.go
+++ b/backend/agent/agent_llm.go
@@ -322,6 +322,7 @@ func getProviderBaseURL(provider, customBaseURL string) string {
 		"together":   "https://api.together.xyz/v1",
 		"novita":     "https://api.novita.ai/v3/openai",
 		"openrouter": "https://openrouter.ai/api/v1",
+		"requesty":   "https://router.requesty.ai/v1",
 
 		// 国内模型
 		"qwen":        "https://dashscope.aliyuncs.com/compatible-mode/v1",

--- a/frontend/src/pages/LLMManager.tsx
+++ b/frontend/src/pages/LLMManager.tsx
@@ -24,6 +24,7 @@ export default function LLMManager() {
     { value: 'together', label: 'together.ai', group: 'international' },
     { value: 'novita', label: 'novita.ai', group: 'international' },
     { value: 'openrouter', label: 'OpenRouter', group: 'international' },
+    { value: 'requesty', label: 'Requesty', group: 'international' },
 
     // 国内模型
     { value: 'qwen', label: '通义千问', group: 'domestic' },


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router, so it flows through the same OpenAI-compatible client path as the other providers.

Changes: add the `requesty` default base URL in `backend/agent/agent_llm.go` (`getProviderBaseURL`) and the provider option in `frontend/src/pages/LLMManager.tsx`. Verified: `go build ./...` and `go vet ./agent/` pass.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.